### PR TITLE
Fix unnecesary warning caused by using /x (RT#88189)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+     Fix unnecesary warning caused by using /x (RT#88189)
+      (Arthur Axel fREW Schmidt and Andrew Main)
+
 1.00 Refactor build system to use Module::Install
 
 0.02 Change is_dodgy_utf8 to is_sane_utf8 after feedback from

--- a/lib/Test/utf8.pm
+++ b/lib/Test/utf8.pm
@@ -190,7 +190,7 @@ sub is_sane_utf8($;$)
   # regexp in scalar context with 'g', meaning this loop will run for
   # each match.  Should only have to run it once, but will redo if
   # the failing case turns out to be allowed in %allowed.
-  while ($string =~ /($re_bit)/ox)
+  while ($string =~ /($re_bit)/o)
   {
     # work out what the double encoded string was
     my $bytes = $1;
@@ -250,7 +250,7 @@ sub is_within_ascii($;$)
   my $name   = shift || "within ascii";
 
   # look for anything that isn't ascii or pass
-  $string =~ /([^\x{00}-\x{7f}])/x or return _pass($name);
+  $string =~ /([^\x{00}-\x{7f}])/ or return _pass($name);
 
   # explain why we failed
   my $dec = ord($1);
@@ -274,7 +274,7 @@ sub is_within_latin_1($;$)
   my $name   = shift || "within latin-1";
 
   # look for anything that isn't ascii or pass
-  $string =~ /([^\x{00}-\x{ff}])/x or return _pass($name);
+  $string =~ /([^\x{00}-\x{ff}])/ or return _pass($name);
 
   # explain why we failed
   my $dec = ord($1);


### PR DESCRIPTION
This fixes really annoying loud warnings like the following:

```
  t/03deu.t ......... Escape literal pattern white space under /x in regex; marked by <-- HERE in m/(|||||| <-- HERE ||||||||||||||||||||||||||| |¡|¢|£|¤|¥|¦|§|¨|©|ª|«|¬|­|®|¯|°|±|²|³|´|µ|¶|·|¸|¹|º
  |»|¼|½|¾|¿|À|Á|Â|Ã|Ä|Å|Æ|Ç|È|É|Ê|Ë|Ì|Í|Î|Ï|Ð|Ñ|Ò|Ó|Ô|Õ|Ö|×|Ø|Ù|Ú|Û|Ü|Ý|Þ|ß|à|á|â|ã|ä|å|æ|ç|è|é|ê|ë|ì|í|î|ï|ð|ñ|ò|ó|ô|õ|ö|÷|ø|ù|ú|û|ü|ý|þ|ÿ)/ at /home/frew/code/Test-utf8/lib/Test/utf8.pm line 184.
  Escape literal pattern white space under /x in regex; marked by <-- HERE in m/(||||||||||||||||||||||||||||||||| |¡|¢|£|¤|¥|¦|§|¨|©|ª|«|¬|­|®|¯|°|±|²|³|´|µ|¶|·|¸|¹|º|»|¼|½|¾|¿|À|Á|Â|Ã|Ä|Å <-- HER
  E |Æ|Ç|È|É|Ê|Ë|Ì|Í|Î|Ï|Ð|Ñ|Ò|Ó|Ô|Õ|Ö|×|Ø|Ù|Ú|Û|Ü|Ý|Þ|ß|à|á|â|ã|ä|å|æ|ç|è|é|ê|ë|ì|í|î|ï|ð|ñ|ò|ó|ô|õ|ö|÷|ø|ù|ú|û|ü|ý|þ|ÿ)/ at /home/frew/code/Test-utf8/lib/Test/utf8.pm line 184.
```
